### PR TITLE
Fix make test: Add . to PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,5 @@ test: all
 	$(MAKE) -Bnd | ./make2graph | dot
 	$(MAKE) -Bnd | ./make2graph -x
 	$(MAKE) -Bnd | ./make2graph --root
-	./makefile2graph
-	./makefile2graph -B
+	PATH=.:$(PATH) ./makefile2graph
+	PATH=.:$(PATH) ./makefile2graph -B


### PR DESCRIPTION
Fix the following error.
make test
...
./makefile2graph
./makefile2graph: line 3: make2graph: command not found
make: **\* [test] Error 127
