### PR TITLE
Omit the Makefile itself in the dependency output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ bin_SCRIPTS = makefile2graph
 pkgdoc_DATA = LICENSE README.md screenshot.png
 man1_MANS = make2graph.1
 
-CFLAGS ?= -std=gnu99 -O3 -Wall -D_GNU_SOURCE
+CFLAGS ?= -Wall -Wextra -std=gnu99 -O3 -Wall -D_GNU_SOURCE
 
 .PHONY: all clean install test
 .DELETE_ON_ERROR:


### PR DESCRIPTION
Dear Pierre,

thanks for this cool tool. I like to contribute a minor improvement that ensures to omit the Makefile itself from the target graph. To me, the output looks much cleaner that way.

Cheers,
Manuel
