### PR TITLE
Fix for "output discrepancy if file already exists" (Issue #12)

### DIFF
--- a/make2graph.c
+++ b/make2graph.c
@@ -277,10 +277,15 @@ static void GraphScan(GraphPtr graph,TargetPtr root,FILE* in, size_t level)
 
 		        TargetPtr child=GraphGetTarget(graph,tName);
 
+			// fprintf(stderr, "a: %zu(%s)->%zu(%s)\n", level, root->name, iLevel, tName);
 		        free(tName);
 
-		        TargetAddChildren(root,child);
-		        GraphScan(graph,child,in,iLevel+1);
+			if(level+1 >= iLevel)
+			    {
+			    TargetAddChildren(root,child);
+			    // fprintf(stderr, "b: %zu(%s)->%zu(%s)\n", level, root->name, iLevel, child->name);
+			    GraphScan(graph,child,in,iLevel+1);
+			    }
 
 		        }
 		    else if(startsWith(line,"Must remake target "))
@@ -295,7 +300,7 @@ static void GraphScan(GraphPtr graph,TargetPtr root,FILE* in, size_t level)
 			     TargetAddChildren(root,GraphGetTarget(graph,tName));
 			     free(tName);
 			     }
-		    else if(startsWith(line,"Finished prerequisites of target file "))
+		    else if(startsWith(line,"Finished prerequisites of target file ") && (iLevel == level+1))
 			{
 			char* tName=targetName(line);
 			if(strcmp(tName,root->name)!=0)

--- a/make2graph.c
+++ b/make2graph.c
@@ -300,7 +300,7 @@ static void GraphScan(GraphPtr graph,TargetPtr root,FILE* in, size_t level)
 			     TargetAddChildren(root,GraphGetTarget(graph,tName));
 			     free(tName);
 			     }
-		    else if(startsWith(line,"Finished prerequisites of target file ") && (iLevel == level+1))
+		    else if(startsWith(line,"Finished prerequisites of target file ") && (level+1 >= iLevel))
 			{
 			char* tName=targetName(line);
 			if(strcmp(tName,root->name)!=0)


### PR DESCRIPTION
Possible fix for Issue #12, please check.
Yields the correct dependencies for the example Makefile in these cases:
```
touch x.a
touch x.a x.b
touch x.a x.b x.z
touch x.b
touch x.z
touch x.a x.b x.z; rm x.a
touch x.a x.b x.z; rm x.z
```
but not in this:
```
touch x.a x.b x.z; rm x.b
```
