### PR TITLE
makefile2graph: support non-english systems

### DIFF
--- a/makefile2graph
+++ b/makefile2graph
@@ -1,3 +1,4 @@
 #!/bin/sh
 set -eu
+export LANG=C
 exec make -nd "$@" |make2graph


### PR DESCRIPTION
My computer being configured in French, `make2graph` is unable to parse `make`’s output. This commit forces a more stable output of `make` across systems.