### PR TITLE
Escape " in target labels for dot output

### DIFF
--- a/make2graph.c
+++ b/make2graph.c
@@ -358,10 +358,20 @@ static void DumpGraphAsDot(GraphPtr g,FILE* out)
 			}
 		else
 			{
+			const char* label=targetLabel(g,t->name);
 			fprintf(out,
-				"n%zu[label=\"%s\", color=\"%s\"];\n",
-				t->id,
-				targetLabel(g,t->name),
+				"n%zu[label=\"",
+				t->id);
+			while(*label)
+				{
+				if(*label=='\"')
+					fputs("\\\"",out);
+				else
+					fputc(*label,out);
+				label++;
+				}
+			fprintf(out,
+				"\", color=\"%s\"];\n",
 				(t->must_remake?"red":"green")
 				);
 			}


### PR DESCRIPTION
make was putting double quotes around some of my target labels, which were not being escaped when output to dot format, such as ```"/home/some_path/src/lnx//../.."/bin/lxbin``` should be output as
```
digraph G {
n72[label="\"/home/some_path/src/lnx//../..\"/bin/lxbin", color="red"];
...
```

Without this fix, the output from make2graph is:
```
digraph G {
n72[label=""/home/some_path/src/lnx//../.."/bin/lxbin", color="red"];
...
```
which causes dot to complain and not create any output:
```
Warning: <stdin>: syntax error in line 2 near '/'
```