### PR TITLE
fix backwards nodes in Mermaid format

### DIFF
--- a/make2graph.c
+++ b/make2graph.c
@@ -494,7 +494,7 @@ static void DumpGraphAsMermaid(GraphPtr g,FILE* out)
 		for(j=0; j< t->n_children; ++j)
 			{
 			TargetPtr c = t->children[j];
-			fprintf(out,"    n%zu --> n%zu\n", t->id , c->id);
+			fprintf(out,"    n%zu --> n%zu\n", c->id, t->id);
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes #42 by changing the order the nodes are written to match the other formats and thus the correct dependency graph

Per the example in the issue, I now get the right order in Mermaid

```bash
make -Bnd | ./make2graph --format=m
flowchart TD
    n2{{"all"}}:::dirty
    n3{{"make2graph"}}:::dirty
    n4("make2graph.c")
    n3 --> n2
    n4 --> n3
```

As we see elsewhere

```bash
make -Bnd | ./make2graph           
digraph G {
n2 [label="all", color="red"];
n3 [label="make2graph", color="red"];
n4 [label="make2graph.c", color="forestgreen"];
n3 -> n2 ; 
n4 -> n3 ; 
}
```